### PR TITLE
Fix error while opening rrd.file

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -401,12 +401,14 @@ function Intel:new (conf)
          promisc   = {counter},
          macaddr   = {counter, self.r.RAL64[0]:bits(0,48)},
          rxbytes   = {counter},
+         rxbits    = {counter},
          rxpackets = {counter},
          rxmcast   = {counter},
          rxbcast   = {counter},
          rxdrop    = {counter},
          rxerrors  = {counter},
          txbytes   = {counter},
+         txbits    = {counter},
          txpackets = {counter},
          txmcast   = {counter},
          txbcast   = {counter},
@@ -835,13 +837,13 @@ function Intel:sync_stats ()
    set(stats.speed, self:link_speed())
    set(stats.status, self:link_status() and 1 or 2)
    set(stats.promisc, self:promisc() and 1 or 2)
-   set(stats.rxbytes, self:rxbytes())
+   set(stats.rxbits, self:rxbytes()*8)
    set(stats.rxpackets, self:rxpackets())
    set(stats.rxmcast, self:rxmcast())
    set(stats.rxbcast, self:rxbcast())
    set(stats.rxdrop, self:rxdrop())
    set(stats.rxerrors, self:rxerrors())
-   set(stats.txbytes, self:txbytes())
+   set(stats.txbits, self:txbytes()*8)
    set(stats.txpackets, self:txpackets())
    set(stats.txmcast, self:txmcast())
    set(stats.txbcast, self:txbcast())

--- a/src/lib/rrd.lua
+++ b/src/lib/rrd.lua
@@ -277,7 +277,11 @@ end
 
 function create_file(filename, arg)
    local rrd = new(arg)
-   local fd = assert(S.open(filename, "creat, rdwr, excl", '0664'))
+   -- File might already exists if directory is a link.
+   local _, fd = pcall(S.open, filename, "rdwr, excl", '0664')
+   if not fd then
+      fd = assert(S.open(filename, "creat, rdwr, excl", '0664'))
+   end
    local f = file.fdopen(fd, 'wronly', filename)
    f:write_bytes(rrd.ptr, rrd.size)
    f:flush_output()


### PR DESCRIPTION
There's an error while starting `lwaftr run`:

```
$ sudo ./snabb lwaftr run --cpu 10,11 --name lwaftr --conf lwaftr.conf --on-a-stick 82:00.0
Binding data-plane PID 18274 to CPU 10.
Bound main process to NUMA node:        1
Binding data-plane PID 18276 to CPU 11.
Error while running fiber: core/main.lua:26: File exists
Error while running fiber: core/main.lua:26: File exists
Error while running fiber: lib/ptree/ptree.lua:383: attempt to index a nil value
```

I think the problem is that rrd counters are created in the same folder as counters. When rrd counters are created int the pci folder, since the folder is now shared a process might to create a rrd counter that already exists.